### PR TITLE
Add naming conventions section and missing templates sub-section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ To request us to review code that you create, you will need to create a pull req
 
 ### [`components`](./components)
 
-All the Tailwindcss Components for the project are stored in `.html` files located within the [`components`](./components) directory.
+All the TailwindCSS Components for the project are stored in `.html` files located within the [`components`](./components) directory.
 
 ## Issue Creation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,13 @@ Issue template types include the following:
  - Bug Reporting
  - Feature Requests
  - Help Requests
+
+## Naming Conventions
+
+### Components
+
+When naming your component file, it's best to stick which a descriptive name. Such as for a component with featured content containing a large image, we named the file `feature-content-image.html`.
+
+### Templates
+
+TBD.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,10 @@ To request us to review code that you create, you will need to create a pull req
 
 All the TailwindCSS Components for the project are stored in `.html` files located within the [`components`](./components) directory.
 
+### [`templates`](./templates)
+
+All the TaildwindCSS Templates for the project are stored in `.html` files located within the [`templates`](./templates) directory.
+
 ## Issue Creation
 
 In the event that you have a issue using the tool or have a suggest for a change but don't want to contribute code,


### PR DESCRIPTION
## What does this PR solve?

This PR partly solves the issue of naming your components by adding a basic naming convention section to the `CONTRIBUTING.md` file. Though writing docs isn't my strong suit so I only added a small bit for the components and left templates TBD. Also included a missing __templates__ sub-section to the __File Location/Types__ section. 🙂

## What does this PR contain.

- Add missing templates sub-section.
- Create a naming conventions section.

## Here's a funny GIF.

![Dancing man with text reading, when you realize its Friday.](https://media.giphy.com/media/7R6OOT8TiA8Gk/giphy.gif)