### PR TITLE
Add missing issue templates and pull request template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: 🐛 Bug report
+about: Create a report to help us improve Tails 🤘
+title: "Bug: "
+labels: bug
+---
+
+<!-- Before creating a bug report, try disabling browser extensions to see if the bug is still present. -->
+
+### Describe the bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+### To Reproduce
+
+<!-- Steps to reproduce the behavior: -->
+
+<!-- 1. Go to '...' -->
+<!-- 2. Click on '....' -->
+<!-- 3. Scroll down to '....' -->
+<!-- 4. See error -->
+
+### Expected behavior
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+### Screenshots
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+### Desktop
+
+- OS:
+- Browser:
+- Version:
+
+### Smartphone
+
+- Device:
+- OS:
+- Browser:
+- Version:
+
+### Additional context
+
+<!-- Add any other context about the problem or helpful links here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: 🚀 Feature request
+about: Suggest an idea for this project 💡
+title: "Feature: "
+labels: feature, enhancement
+---
+
+### Is your feature request related to a problem? Please describe.
+
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+### Describe the solution you'd like
+
+<!-- A clear and concise description of what you want to happen. -->
+
+### Describe alternatives you've considered
+
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+### Additional context
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/help_request.md
+++ b/.github/ISSUE_TEMPLATE/help_request.md
@@ -1,0 +1,15 @@
+---
+name: 🖐 Help request
+about: I need help with an issue 😕
+title: "Help: "
+labels: help wanted
+---
+
+### Please fill out this template
+
+<!-- A clear and concise description of what the problem is. Ex. I need help with [...] -->
+
+
+### Additional context
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--
+  For Work In Progress Pull Requests, please use the Draft PR feature,
+  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
+  
+  For a timely review/response, please avoid force-pushing additional
+  commits if your PR already received reviews or comments.
+  
+  Before submitting a Pull Request, please ensure you've done the following:
+  - 📖 Read the Tails Contributing Guide: https://github.com/thedevdojo/tails/blob/HEAD/CONTRIBUTING.md#creating-a-pull-request.
+  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
+  - 📝 Use descriptive commit messages.
+  - 📗 Update any related documentation and include any relevant screenshots.
+-->
+
+## What type of PR is this? (check all applicable)
+
+- [ ] ♻️ Refactor
+- [ ] ✨ Feature
+- [ ] 🐛 Bug Fix
+- [ ] 👷 Optimization
+- [ ] 📝 Documentation Update
+- [ ] 🚩 Other
+
+## Description
+
+
+
+## Related Tickets & Documents
+
+
+
+## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
+
+
+
+## Added to documentation?
+
+- [ ] 📜 readme
+- [ ] 🙅 no documentation needed
+
+## [optional] What gif best describes this PR or how it makes you feel?


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Created some basic templates, mostly ripped from the [open-sauced/swag] repository, the repo feels seems to match, plus I liked the vibe open-sauced gives off. 🙂

Does include an un-finished `help_request.md` issue template, wasn't sure what to add-in there. Will leave the up to you. 👍

## Related Tickets & Documents

[Issue Creation] has a section mentioning issue templates but none exists.

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Bull Murray in Space Jam saying perhaps I could be of some assistance](https://media.giphy.com/media/l0ErK5H6exTmBN7ri/giphy.gif)

[issue creation]: https://github.com/thedevdojo/tails/blob/master/CONTRIBUTING.md#issue-creation
[open-sauced/swag]: https://github.com/open-sauced/swag