### PR TITLE
Fix button corners on GitHub Buttons

### DIFF
--- a/components/button-github.html
+++ b/components/button-github.html
@@ -1,8 +1,8 @@
 <div class="flex items-center w-full h-screen mx-6 bg-white md:m-0 md:justify-center">
     <ul class="flex flex-col items-start space-y-4 md:flex-row md:space-y-0 md:space-x-4">
-        <li class="flex text-sm leading-none text-gray-900 border border-gray-400 rounded-md">
+        <li class="flex text-sm leading-none text-gray-900">
             <button
-                class="flex items-center px-3 py-2 space-x-2 bg-gray-200 border-r border-gray-400 rounded-l-sm hover:bg-gray-300 focus:bg-gray-300 focus:outline-none">
+                class="flex items-center px-3 py-2 space-x-2 bg-gray-200 border border-gray-400 rounded-l-md hover:bg-gray-300 focus:bg-gray-300 focus:outline-none">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-700" viewBox="0 0 20 20"
                     fill="currentColor">
                     <path
@@ -10,13 +10,13 @@
                 </svg>
                 <span class="font-semibold">Unstar</span>
             </button>
-            <a class="flex items-center px-3 py-2 font-semibold" href="#_">124</a>
+            <a class="flex items-center -ml-px px-3 py-2 font-semibold border border-gray-400 rounded-r-md" href="#_">124</a>
         </li>
         <li x-data="{ open: true }"
-            class="flex items-center justify-center text-gray-900 border border-gray-400 rounded-md">
+            class="flex items-stretch justify-center text-gray-900">
             <section class="relative flex text-sm leading-none">
                 <button
-                    class="flex items-center px-3 py-2 space-x-2 bg-gray-200 border-r border-gray-400 rounded-l-sm hover:bg-gray-300 focus:outline-none"
+                    class="flex items-center px-3 py-2 space-x-2 bg-gray-200 border border-gray-400 rounded-l-md hover:bg-gray-300 focus:outline-none"
                     @click="open = true" aria-haspopup="true">
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-700" viewBox="0 0 20 20"
                         fill="currentColor">
@@ -66,11 +66,11 @@
                     </div>
                 </aside>
             </section>
-            <a class="flex items-center px-3 py-2 text-sm font-semibold leading-none" href="#_">4</a>
+            <a class="flex items-center -ml-px px-3 py-2 text-sm font-semibold leading-none border border-gray-400 rounded-r-md" href="#_">4</a>
         </li>
-        <li class="text-gray-900 border border-gray-400 rounded-md">
+        <li class="text-gray-900">
             <button
-                class="flex items-center px-3 py-2 space-x-2 text-sm leading-none bg-gray-200 rounded-sm hover:bg-gray-300 focus:outline-none focus:bg-gray-300">
+                class="flex items-center px-3 py-2 space-x-2 text-sm leading-none bg-gray-200 border border-gray-400 rounded-md rounded-md hover:bg-gray-300 focus:outline-none focus:bg-gray-300">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-700" viewBox="0 0 20 20"
                     fill="currentColor">
                     <path fill-rule="evenodd"


### PR DESCRIPTION
#29  What type of PR is this? (check all applicable)

- [X] ♻️ Refactor
- [ ] ✨ Feature
- [X] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Fixes the very small gap between button backgrounds and borders – this is more apparent when the colors have more contrast.

The inner `rounded-sm` is peeking out of its container, and at some zoom levels, a gap can be seen between the elements and their parent `<li>` with the border applied.

Normally, a quick `overflow-hidden` would fix the corner clipping, but then the dropdown menu would get hidden too. So, I have moved the `border` and `rounded-md` classes a layer deeper.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Forgive the seafoam; only used to display the bug!

### Before

![image](https://user-images.githubusercontent.com/6765732/97068839-c5075c80-1590-11eb-8889-180ee5cbe0f5.png)

![image](https://user-images.githubusercontent.com/6765732/97068873-10ba0600-1591-11eb-8d30-4d7cde8f13a1.png)

### After

![image](https://user-images.githubusercontent.com/6765732/97068868-05ff7100-1591-11eb-8aed-58e79e13b866.png)

![image](https://user-images.githubusercontent.com/6765732/97068875-1879aa80-1591-11eb-97f5-16eb70adc08b.png)

## Added to documentation?

- [ ] 📜 readme
- [X] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media3.giphy.com/media/l378rhA6c1QhJDgbu/giphy.gif)