### PR TITLE
fix section heading for ordering

### DIFF
--- a/templates/flare.html
+++ b/templates/flare.html
@@ -288,7 +288,7 @@
                         <div class="flex flex-col items-center px-2 py-12 bg-white border-2 border-black rounded-lg lg:px-5 xl:px-12 md:rounded-r-none md:rounded-l-lg">
 
                             <div class="font-light"><span class="font-bold text-yellow-500">Basic</span> Plan</div>
-                            <h4 class="flex items-center my-2 text-5xl font-black"><span class="mr-1 text-2xl font-light text-gray-800">$</span>48</h4>
+                            <h3 class="flex items-center my-2 text-5xl font-black"><span class="mr-1 text-2xl font-light text-gray-800">$</span>48</h3>
                             <span class="w-1/2 h-1 bg-yellow-400"></span>
 
                             <div class="flex flex-col justify-start w-full px-6 py-10">
@@ -363,7 +363,7 @@
                         <div class="flex flex-col items-center px-2 py-12 my-8 bg-white border-2 border-black rounded-lg md:border-l-0 md:border-r-0 md:my-0 md:rounded-none lg:px-5 xl:px-12">
 
                             <div class="font-light"><span class="font-bold text-green-400">Pro</span> Plan</div>
-                            <h4 class="flex items-center my-2 text-5xl font-black"><span class="mr-1 text-2xl font-light text-gray-800">$</span>98</h4>
+                            <h3 class="flex items-center my-2 text-5xl font-black"><span class="mr-1 text-2xl font-light text-gray-800">$</span>98</h3>
                             <span class="w-1/2 h-1 bg-green-400"></span>
 
                             <div class="flex flex-col justify-start w-full px-6 py-10">
@@ -438,7 +438,7 @@
                         <div class="flex flex-col items-center px-2 py-12 ml-0 bg-white border-2 border-black rounded-lg lg:px-6 xl:px-12 md:rounded-l-none md:rounded-r-lg">
 
                             <div class="font-light"><span class="font-bold text-purple-500">Premium</span> Plan</div>
-                            <h4 class="flex items-center my-2 text-5xl font-black"><span class="mr-1 text-2xl font-light text-gray-800">$</span>68</h4>
+                            <h3 class="flex items-center my-2 text-5xl font-black"><span class="mr-1 text-2xl font-light text-gray-800">$</span>68</h3>
                             <span class="w-1/2 h-1 bg-purple-400"></span>
 
                             <div class="flex flex-col justify-start w-full px-6 py-10">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Section headings h1/h2 ect. should come in order, this fix makes h4 into h3, no font changes takes place.

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed
